### PR TITLE
Fix link sanitization

### DIFF
--- a/scripts/corpse/layout.js
+++ b/scripts/corpse/layout.js
@@ -73,7 +73,7 @@ function Layout(host)
 
   this.link = function(target)
   {
-    var name = target.replace("/","").trim();
+    var name = target.replace(/^\//,"").trim();
 
     // External
     if(target.match(/^http|^dat/)){

--- a/scripts/corpse/layout.js
+++ b/scripts/corpse/layout.js
@@ -76,7 +76,7 @@ function Layout(host)
     var name = target.replace("/","").trim();
 
     // External
-    if(target.indexOf("http") > -1){
+    if(target.match(/^http|^dat/)){
       window.open(target,'_blank');
     }
     else{


### PR DESCRIPTION
`dat://` links were not recognized as external links leading to the 'Website' link on http://wiki.xxiivv.com/#Rotonde to not open correctly.

Also improved the logic of [line #76 in layout.js](https://github.com/XXIIVV/oscean/compare/master...lejeunerenard:fix-link-santitization?expand=1#diff-3cb7927381b044b9afcb4941cc56ea18R76) assuming its purpose was to remove the root `/`. This way it will not remove `/`s except when they are the first character.