### PR TITLE
Fixed links on Paradise entry

### DIFF
--- a/scripts/database/lexicon.ndtl
+++ b/scripts/database/lexicon.ndtl
@@ -1037,7 +1037,7 @@ PARADISE
   ICON : M150.0,60.0 L150.0,60.0 L150.0,135.0 M227.9,195.0 L227.9,195.0 L163.0,157.5 M72.1,195.0 L72.1,195.0 L137.0,157.5
   BODY
     & In {(bold "Paradise")}, you are but a force acting upon places, objects, words — vessels.
-    & {(bold "Paradise")} is currently being expanded into an {(link "https://github.com/hundredrabbits/Paradise" "experimental shell")}, and file-system, for an upcoming light Linux distribution. The project also features an inline scripting language inspired from {(link "https://en.wikipedia.org/wiki/Lisp_(programming_language)" "LISP")}, called {(link "https://github.com/hundredrabbits/Paradise/blob/master/WILDCARDS.md" "WildcardLISP")}.
+    & {(bold "Paradise")} is currently being expanded into an {(link "https://github.com/hundredrabbits/Paradise" "experimental shell")}, and file-system, for an upcoming light Linux distribution. The project also features an inline scripting language inspired from {(link "https://en.wikipedia.org/wiki/Lisp_(programming_language)" "LISP")}, called {(link "Lain")}.
     # create a coffee machine
     # enter the machine
     # program create a coffee

--- a/scripts/database/lexicon.ndtl
+++ b/scripts/database/lexicon.ndtl
@@ -1037,7 +1037,7 @@ PARADISE
   ICON : M150.0,60.0 L150.0,60.0 L150.0,135.0 M227.9,195.0 L227.9,195.0 L163.0,157.5 M72.1,195.0 L72.1,195.0 L137.0,157.5
   BODY
     & In {(bold "Paradise")}, you are but a force acting upon places, objects, words — vessels.
-    & {(bold "Paradise")} is currently being expanded into an {(link "https://github.com/hundredrabbits/Paradise" "experimental shell")}, and file-system, for an upcoming light Linux distribution. The project also features an inline scripting language inspired from {(link "https://en.wikipedia.org/wiki/Lisp_" "LISP")}, called {(link "https://github.com/hundredrabbits/Paradise/blob/master/WILDCARDS.md" "WildcardLISP")}.
+    & {(bold "Paradise")} is currently being expanded into an {(link "https://github.com/hundredrabbits/Paradise" "experimental shell")}, and file-system, for an upcoming light Linux distribution. The project also features an inline scripting language inspired from {(link "https://en.wikipedia.org/wiki/Lisp_(programming_language)" "LISP")}, called {(link "https://github.com/hundredrabbits/Paradise/blob/master/WILDCARDS.md" "WildcardLISP")}.
     # create a coffee machine
     # enter the machine
     # program create a coffee


### PR DESCRIPTION
It was linking to `LISP_` instead of `Lisp_(programming_language)` ;P

Edit: I did check other links, there was one other that is already correct.