### PR TITLE
Fix navigation by URL bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,28 +65,9 @@
 
     lain.run(`(${PROJECTS.prelude+PROJECTS.graph+PROJECTS.template})`)
 
-    const detectPage = function (onChange) {
-      let hashHistory = [window.location.hash]
-      let historyLength = window.history.length
-      return () => {
-        let hash = window.location.hash; let length = window.history.length
-        if (hashHistory.length && historyLength === length) {
-          if (hashHistory[hashHistory.length - 2] === hash) {
-            hashHistory = hashHistory.slice(0, -1)
-          } else {
-            hashHistory.push(hash)
-          }
-          onChange()
-        } else {
-          hashHistory.push(hash)
-          historyLength = length
-        }
-      }
-    }
-
-    window.addEventListener('hashchange', detectPage((e) => { 
+    window.addEventListener('hashchange', (e) => { 
       BINDINGS.change(window.location.hash.replace(/\+/g,' ').replace('#','')) 
-    }))
+    })
 
     window.addEventListener('load', (e) => { 
       BINDINGS.start(window.location.hash.replace(/\+/g,' ').replace('#','')) 


### PR DESCRIPTION
Looks like it was already intended to work this way, but broken. I am not sure what `detectPage` was supposed to be doing, because it functions perfectly fine like this.

Fixes #36
