### PR TITLE
Add overflow styling to pre tags

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -11,7 +11,7 @@ nav ul li a:hover { background:black;color:white }
 main { max-width:624px;clear:both }
 main figure:first-child img { margin-left:-30px;max-width:calc(100vw - 15px);width:900px }
 main figure figcaption { font-size:14px;max-width:400px }
-main pre { border: 1px solid black;padding:15px }
+main pre { border: 1px solid black;padding:15px;overflow:auto }
 main h2 { max-width:400px } 
 main h4 { font-style: italic;font-weight: normal } 
 main ul, main ol { margin: 0 30px 30px 30px }


### PR DESCRIPTION
I'm seeing an overflow bug for `pre` tags on the live site (see screenshot below). I think it originated here: 0ac8b61. I used `overflow` because it enjoys better browser support than `overflow-x` and it seems to only affect the horizontal overflow in this situation. Wdyt? Is there a simpler way to hide the overflow?

---
![overflow-x](https://user-images.githubusercontent.com/64905401/83330411-e9fadc00-a24b-11ea-8eea-aef029ea6488.jpg)

---
Seen in Chrome Version 80.0.3987.163 (Official Build) (64-bit)