### PR TITLE
Propose correction to radio.htm

### DIFF
--- a/src/inc/radio.htm
+++ b/src/inc/radio.htm
@@ -1,4 +1,4 @@
-<p>Frequencies below 2MHz are reflected off the atmosphere, thus they can follow the Earth's curvature. So these low frequency signals can sometimes be received by radios below the horizon hundreds of miles away. As a general rule, the lower the frequency, the greater distance it can travel. Unlike frequencies below 2MHz, radio waves in higher frequencies(VHF/UHF) travel in straight lines (line-of-sight) generally cannot travel beyond the horizon.</p>
+<p>Frequencies below about 30MHz are reflected off the atmosphere, thus they can follow the Earth's curvature. So these low frequency signals can sometimes be received by radios below the horizon hundreds of miles away. As a general rule, the lower the frequency, the greater distance it can travel. Unlike frequencies below 30MHz, radio waves in higher frequencies(VHF/UHF) travel in straight lines (line-of-sight) generally cannot travel beyond the horizon.</p>
 
 <table border="1">
   <tr><td>VHF (Very High Frequency)</td><td>130-174MHz</td></tr>


### PR DESCRIPTION
The main transmission mode for HF (aka shortwave) is bouncing off the atmosphere. This happens below about 30MHz. Below about 1MHz what you get is ground-wave, that's where you find regional broadcast AM radio stations. HF used to be more common on sailboats, it's good offshore. It's a shame that most people have forgotten about it. It's hard to get the marine HF license without taking expensive merchant marine courses, but an amateur license is easy.

VE0HAK