### PR TITLE
Fix minor typo

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -757,7 +757,7 @@ fphtml(FILE *f, Glossary *glo, Lexicon *lex, Term *t, Journal *jou)
 	if(t->type && scmp(t->type, "alias"))
 		alias = findterm(lex, t->host);
 	fputs("<!DOCTYPE html><html lang='en'>", f);
-	fputs("</head>", f);
+	fputs("<head>", f);
 	fprintf(f, "<meta charset='utf-8'>"
 			   "<meta name='description' content='%s'/>"
 			   "<meta name='thumbnail' content='" DOMAIN "media/services/thumbnail.jpg' />"


### PR DESCRIPTION
https://github.com/XXIIVV/oscean/blob/master/src/main.c#L760

`</head>` should likely be `<head>`.

This is in the page source on the deployed site. I'm guessing that some browsers handle gracefully.
![image](https://user-images.githubusercontent.com/339996/103471809-ac66b000-4d52-11eb-87eb-e7647bb6f9d1.png)

I'm really digging this project, inspired me to do something similar - hence the line by line read of `main.c`. Cheers.