### PR TITLE
Correct typos in the table of verb's conjugations

### DIFF
--- a/src/inc/html/japanese.htm
+++ b/src/inc/html/japanese.htm
@@ -66,14 +66,14 @@
 <p>These verbs end in う, く, ぐ, ぶ, む, ぬ, す, つ, or ある・いる・うる・える・おる. Typically you drop ーう and add something else. The problem is that there might be a phonetic change, such as when は becomes ぱ, or た becomes だ.</p>
 
 <table border='1'>
-  <tr><td><b>talk</b> </td><td>はな</td><td>話す </td><td>話して</td><td>話しった </td><td>話したら</td><td>話せ</td><td>話さない</td><td>話せる</td></tr>
-  <tr><td><b>walk</b> </td><td>きく</td><td>きく　</td><td>きいて </td><td>聞いた</td><td>聞いたら</td><td>聞け</td><td>聞かない </td><td>聞ける</td></tr>
-  <tr><td><b>swim</b> </td><td>およぐ </td><td>泳ぐ</td><td>泳いでる</td><td>泳いだ</td><td>泳いだら</td><td>泳げ</td><td>泳がない</td><td>泳げる</td></tr>
-  <tr><td><b>call</b> </td><td>よび</td><td>呼ぶ　</td><td>呼んで </td><td>呼んだ</td><td>呼んだら</td><td>呼べ </td><td>呼ばない </td><td>呼べる</td></tr>
-  <tr><td><b>drink</b></td><td>ぬも</td><td>飲む　</td><td>飲んで </td><td>飲んだ</td><td>飲んだら</td><td>飲め </td><td>飲まない </td><td>飲める</td></tr>
+  <tr><td><b>talk</b> </td><td>はなす</td><td>話す </td><td>話して</td><td>話しった </td><td>話したら</td><td>話せ</td><td>話さない</td><td>話せる</td></tr>
+  <tr><td><b>hear</b> </td><td>きく</td><td>聞く　</td><td>聞いて </td><td>聞いた</td><td>聞いたら</td><td>聞け</td><td>聞かない </td><td>聞ける</td></tr>
+  <tr><td><b>swim</b> </td><td>およぐ </td><td>泳ぐ</td><td>泳いで</td><td>泳いだ</td><td>泳いだら</td><td>泳げ</td><td>泳がない</td><td>泳げる</td></tr>
+  <tr><td><b>call</b> </td><td>よぶ</td><td>呼ぶ　</td><td>呼んで </td><td>呼んだ</td><td>呼んだら</td><td>呼べ </td><td>呼ばない </td><td>呼べる</td></tr>
+  <tr><td><b>drink</b></td><td>のむ</td><td>飲む　</td><td>飲んで </td><td>飲んだ</td><td>飲んだら</td><td>飲め </td><td>飲まない </td><td>飲める</td></tr>
   <tr><td><b>die</b></td><td>しぬ</td><td>死ぬ　</td><td>死んで </td><td>死んだ</td><td>死んだら</td><td>死ね </td><td>死なない </td><td>死ねる</td></tr>
   <tr><td><b>make</b> </td><td>つくる</td><td>作る　</td><td>作って</td><td>つ作った </td><td>作ったら</td><td>作れ</td><td>作らない</td><td>作れる</td></tr>
-  <tr><td><b>wait</b> </td><td>まて</td><td>待つ　</td><td>待って </td><td>待った</td><td>待ったら</td><td></td><td>待たない</td><td>待てる</td></tr>
+  <tr><td><b>wait</b> </td><td>まつ</td><td>待つ　</td><td>待って </td><td>待った</td><td>待ったら</td><td>待て</td><td>待たない</td><td>待てる</td></tr>
   <tr><td><b>pay</b></td><td>はらう </td><td>払う</td><td>払って</td><td>払った </td><td>払ったら</td><td>払え</td><td>払わない</td><td>払える</td></tr>
 </table>
 


### PR DESCRIPTION
Checked these words' readings and translations in the WWWJDIC (o^^o)♪

>話す(P); 咄す 【**はなす**】 (v5s,vt) (1) to talk; to speak; to converse; to chat; (v5s,vt)
>**聞く**(P); 聴く(P) 【きく】 (v5k,vt) **(1) to hear;**
>呼ぶ(P); 喚ぶ; 招ぶ(iK) 【**よぶ**】 (v5b,vt) (1) to call out (to); to call; to invoke; (v5b,vt) 
>飲む(P); 呑む(P); 飮む(oK) 【**のむ**】 (v5m,vt) (1) (呑む often means swallowing whole, gulping, etc.) to drink; to gulp; to swallow; to take (medicine); (v5m,vt)
>待つ(P); 俟つ 【**まつ**】 (v5t,vt,vi) (1) (待つ only) to wait; (v5t,vt,vi)

Changed きく and きいて so they are written with kanji like in other cells of the table.

Also added imperative form **待て** and corrected -te form of 泳ぐ (checked these in OJAD)