### PR TITLE
Fix links on ansi_c

### DIFF
--- a/src/inc/html/ansi_c.htm
+++ b/src/inc/html/ansi_c.htm
@@ -1,6 +1,6 @@
 <h3>Compile</h3>
 
-<p>To convert source to an executable binary one uses a compiler. My compiler of choice is {https://bellard.org/tcc tcc}, but more generally <code>gcc</code> is what most toolchains will use on {Linux}.</p>
+<p>To convert source to an executable binary one uses a compiler. My compiler of choice is <a href='https://bellard.org/tcc' target='_blank'>tcc</a>, but more generally <a href='https://gcc.gnu.org/' target='_blank'>gcc</a> is what most toolchains will use on <a href='linux.html'>Linux</a>.</p>
 
 <pre>cc -Wall -o main main.c</pre>
 


### PR DESCRIPTION
I noticed some text that seemed to be trying to be links, but weren't, so I fixed them/improved them.