### PR TITLE
Fix table header mismatch

### DIFF
--- a/src/content/fractran.htm
+++ b/src/content/fractran.htm
@@ -9,7 +9,7 @@
 
 <table border='1'>
 	<tr><th rowspan='2'>Accumulator</th><th colspan='4'>Registers</th></tr>
-	<tr><th></th><th>r2</th><th>r3</th><th>r5</th><th>r7</th></tr>
+	<tr><th>r2</th><th>r3</th><th>r5</th><th>r7</th></tr>
 	<tr><th>6</th><td>1</td><td>1</td><td></td><td></td></tr>
 	<tr><th>18</th><td>1</td><td>2</td><td></td><td></td></tr>
 	<tr><th>1008</th><td>4</td><td>2</td><td></td><td>1</td></tr>


### PR DESCRIPTION
On "Fractran", the table under "The Accumulator" had the headers off by one. The `rowspan="2"` of the "Accumulator" takes over the empty header space, so removing the extra `<th></th>` aligns them again.