### PR TITLE
Fix links with references to renamed default Git branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oscean
 
-This is the repository for the [Oscean wiki](http://wiki.xxiivv.com/), see the [on-site documentation](http://wiki.xxiivv.com/site/about.html) for more up-to-date details. Oscean is a _static site_ written in [Uxntal](https://wiki.xxiivv.com/site/uxntal.html), a stack-machine assembly language designed for a [portable virtual machine](https://git.sr.ht/~rabbits/uxn/). The database tables are stored as plain-text files designed to fit in Uxn's 64kb of memory. The Master Branch is the **live version**.
+This is the repository for the [Oscean wiki](http://wiki.xxiivv.com/), see the [on-site documentation](http://wiki.xxiivv.com/site/about.html) for more up-to-date details. Oscean is a _static site_ written in [Uxntal](https://wiki.xxiivv.com/site/uxntal.html), a stack-machine assembly language designed for a [portable virtual machine](https://git.sr.ht/~rabbits/uxn/). The database tables are stored as plain-text files designed to fit in Uxn's 64kb of memory. The `main` branch is the **live version**.
 
 ## Build
 

--- a/archive/main.c
+++ b/archive/main.c
@@ -15,7 +15,7 @@
 #define NAME "XXIIVV"
 #define DOMAIN "https://wiki.xxiivv.com/"
 #define LOCATION "Sidney, Canada"
-#define REPOPATH "https://github.com/XXIIVV/oscean/blob/master/src/"
+#define REPOPATH "https://github.com/XXIIVV/oscean/tree/main/src"
 
 typedef struct Block {
 	int len;

--- a/src/content/about.htm
+++ b/src/content/about.htm
@@ -19,7 +19,7 @@
 
 <p><i>Under the following terms</i>: <b>Attribution</b>: You must give appropriate credit. <b>NonCommercial</b>: You may not use the material for commercial purposes. <b>ShareAlike</b>: You must distribute your contributions under the same license.</p>
 
-<p>You can learn more about the <a href='oscean.html'>related tools</a> by visiting the <a href='nataniev.html'>nataniev</a> portal, or by reading the <a href='faqs.html'>faqs</a>. You can download a copy of the entire website content and sources as a <a href='https://github.com/XXIIVV/Oscean/archive/master.zip' target='_blank'>.zip</a>.</p>
+<p>You can learn more about the <a href='oscean.html'>related tools</a> by visiting the <a href='nataniev.html'>nataniev</a> portal, or by reading the <a href='faqs.html'>faqs</a>. You can download a copy of the entire website content and sources as a <a href='https://github.com/XXIIVV/oscean/archive/refs/heads/main.zip' target='_blank'>.zip</a>.</p>
 
 <p>If you have any <b>question or feedback</b>, please submit a <a href='https://github.com/XXIIVV/Oscean/issues/new' target='_blank'>bug report</a>, for any additional informations, contact <a href='devine_lu_linvega.html'>Devine Lu Linvega</a>. </p>
 

--- a/src/content/bifurcan.htm
+++ b/src/content/bifurcan.htm
@@ -3,10 +3,10 @@
 <p>Every second, <i>the Labyrinth</i> reorganize itself to display the time in twists and turns.</p>
 <p>It takes a little practice to be able to see the patterns in the lines. Clicking on the screen will change to a <a href='https://youtu.be/5U4cAs_gTE8' target='_blank'>different pattern</a>.</p>
 <p>If you have a <a href='https://getpebble.com' target='_blank'>Pebble Watch</a>, you can download it as a <a href='http://www.mypebblefaces.com/apps/10183/7055/' target='_blank'>watchface</a>, the Pebble C script was written by Chase Colburn and is also available on <a href='https://github.com/chasecolburn/line-maze' target='_blank'>Github</a>. The screensaver version was done by <a href='http://tekgo.org' target='_blank'>Tekgo</a> and was also added to the source code. Named after a <a href='http://en.wikipedia.org/wiki/The_Garden_of_Forking_Paths' target='_blank'>Borges short</a>.</p>
-<p>The application was re-written in <a href='uxntal.html'>Uxntal</a> in 2021, see the full source <a href='https://git.sr.ht/~rabbits/uxn/tree/master/item/projects/examples/demos/bifurcan.tal' target='_blank'>here</a>.</p>
+<p>The application was re-written in <a href='uxntal.html'>Uxntal</a> in 2021, see the full source <a href='https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/examples/demos/bifurcan.tal' target='_blank'>here</a>.</p>
 
 <ul>
-	<li><a href='https://git.sr.ht/~rabbits/uxn/tree/master/item/projects/examples/demos/bifurcan.tal' target='_blank'>uxn</a></li>
+	<li><a href='https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/examples/demos/bifurcan.tal' target='_blank'>uxn</a></li>
 	<li><a href='https://github.com/Echorridoors/Bifurcan' target='_blank'>obj-c</a></li>
 	<li><a href='http://www.mypebblefaces.com/apps/10183/7055/' target='_blank'>pebble</a></li>
 </ul>

--- a/src/content/cellular_automata.htm
+++ b/src/content/cellular_automata.htm
@@ -12,6 +12,6 @@
 
 <ul>
 	<li><a href='https://conwaylife.com/wiki/Main_Page' target='_blank'>GOL Wiki</a></li>
-	<li><a href='https://git.sr.ht/~rabbits/uxn/tree/master/item/projects/examples/demos/life.tal' target='_blank'>Uxn Implementation</a></li>
+	<li><a href='https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/examples/demos/life.tal' target='_blank'>Uxn Implementation</a></li>
 </ul>
 

--- a/src/content/lietal.htm
+++ b/src/content/lietal.htm
@@ -122,6 +122,6 @@
   .mono { font-family:monospace; }
   .pair { background:pink; }
 </style><ul>
-	<li><a href='https://github.com/XXIIVV/oscean/tree/master/src/projects/lietal' target='_blank'>ANSI C Library</a></li>
+	<li><a href='https://github.com/XXIIVV/oscean/tree/main/archive/projects/lietal' target='_blank'>ANSI C Library</a></li>
 </ul>
 

--- a/src/content/neralie.htm
+++ b/src/content/neralie.htm
@@ -5,7 +5,7 @@
 <p>Neralie time is similar to the <a href='https://en.wikipedia.org/wiki/Swatch_Internet_Time' target='_blank'>Swatch Internet Time</a> decimal clock, but uses 6 decimal points and a rectangular watchface. You can find a <a href='pascal.html'>pascal</a> implementation for <a href='macintosh.html'>macintosh</a>, in the <a href='https://github.com/XXIIVV/Clock/tree/master/pascal' target='_blank'>clock repository</a>.</p>
 
 <ul>
-	<li><a href='https://github.com/XXIIVV/oscean/tree/master/src/projects/neralie' target='_blank'>ANSI C Library</a></li>
+	<li><a href='https://github.com/XXIIVV/oscean/tree/main/archive/projects/neralie' target='_blank'>ANSI C Library</a></li>
 	<li><a href='https://clock.xxiivv.com' target='_blank'>view online</a></li>
 </ul>
 

--- a/src/content/tablatal.htm
+++ b/src/content/tablatal.htm
@@ -11,7 +11,7 @@ Ruca    45    Grey
 </pre>
 
 <p>Or, <code>[&#123;name:Erica,Age:12,Color:Blue&#125;,&#123;name:Alex,Age..&#125;</code></p><ul>
-	<li><a href='https://github.com/XXIIVV/oscean/blob/master/src/projects/utils/ndtl.sublime-syntax' target='_blank'>syntax highlight</a></li>
+	<li><a href='https://github.com/XXIIVV/oscean/blob/main/archive/projects/utils/ndtl.sublime-syntax' target='_blank'>syntax highlight</a></li>
 	<li><a href='https://github.com/milofultz/tablatal_parser' target='_blank'>python parser</a></li>
 </ul>
 


### PR DESCRIPTION
This is all the broken or outdated references to `master` branch I could find. It also includes some links to files that were moved to `archive/`.

This should fix a lot of outgoing 404s!