### PR TITLE
uxntal_reference: Fix documentation for SFT

### DIFF
--- a/src/content/uxntal_reference.htm
+++ b/src/content/uxntal_reference.htm
@@ -285,7 +285,7 @@ Pushes the result of the bitwise operation XOR, to the top of the stack.</p>
 <p>
 <code class='op'>SFT</code>
 <code class="sig">a b^ -- c</code>
-Moves the bits of the value at the top of the stack to the left or right, depending on the control value of the second. The high nibble of the control value determines how many bits left to shift, and the low nibble how many bits right to shift. The rightward shift is done first.</p>
+Moves the bits of the second value of the stack to the left or right, depending on the control value at the top of the stack. The high nibble of the control value determines how many bits left to shift, and the low nibble how many bits right to shift. The rightward shift is done first.</p>
 
 <style>
 .clr0 { background:white; color:black; }


### PR DESCRIPTION
Description had the order of values switched.