### PR TITLE
technology: add alt text to images

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -22,7 +22,7 @@ main ul, main ol { margin:0 30px 30px 30px;clear:both }
 main ul ul { margin-bottom:0 }
 main p { line-height:160% } 
 main ::selection { background-color:#72dec2;color:#000;text-decoration:none } 
-main a:hover { background-color:#000;color:#fff;text-decoration:none } 
+main a:hover, main a:hover > * { background-color:#000;color:#fff;text-decoration:none } 
 main a:before { content:"{" }
 main a:after { content:"}" }
 main a[target="_blank"]:before { content:"[" }

--- a/src/content/collapse.htm
+++ b/src/content/collapse.htm
@@ -2,14 +2,14 @@
 
 <p>Collapse is the transition away from a globalized, hyperconnected and materially-abundant society, toward a state of greater precariousness, lesser abundance, potentially reaching a stage of existential risk for our species. </p>
 
-<img src='../media/refs/seneca.cliff.png'/>
+<img src='../media/refs/seneca.cliff.png' alt='A graph of production over time that steadily increases before dropping rapidly'/>
 
 <p>At the peak of the <i>Seneca Cliff</i>, the curve that describes the rapid phase transitions of complex systems on the basis of the principle that "growth is sluggish, but ruin is rapid." We see a green valley in the distance, but the road down the cliff is so steep and rough that it is hard to say whether we will survive the descent. </p>
 
 <q>Institutions will try to preserve the problem to which they are the <a href='stack.html'>solution</a>.</q>
 <h5>—Clay Shirky</h5>
 
-<img src='../media/refs/hand.glove.jpg'/>
+<img src='../media/refs/hand.glove.jpg' alt='Dark City (1998)'/>
 
 <p><i>Hope</i>, while once a useful trait, is what has condemned us, because we literally cannot see the cliff as we dance off it. Instead of celebrating the failed audacity of hope, it might be prudent to contemplate, in the time we have left, the paucity of hope - because the most we can realistically hope for, trapped by forgone conclusions, is to vanquish fear and find the grace of acceptance.</p>
 

--- a/src/content/simulacra.htm
+++ b/src/content/simulacra.htm
@@ -9,13 +9,18 @@
 
 <p>What we consider to be social reality is indefinitely reproducible and extendable, with the copy indistinguishable from the original, or perhaps seeming more real than the original. </p>
 
-<img src='../media/refs/spectacle.jpg' width='500'/>
+<figure>
+    <img src='../media/refs/spectacle.jpg' width='500' alt='La société du spectacle wrapped around a brick'/>
+    <figcaption>
+        <a href='https://exhibits.haverford.edu/ificantdancetoit/essays/if-i-cant-dance-to-it/'>Claire Fontaine, <cite>La sociéte du spectacle brickbat</cite>, 2005</a>
+    </figcaption>
+</figure>
 
 <p>The modern progress economy dealt in technological potential and progress, whereas the postmodern innovation economy dealt in windows of opportunity that open and close. No one cares about your product; we care about your adoption. No one cares about what your <a href='technology.html'>technology</a> does; we care about what problems it solves for users, and how fast you can grow. </p>
 
 <p>Production and the ideals of production have been so <a href='technocracy.html'>successful</a>, that a new stage is reached, a stage that has a certain banality or triviality where the ideal disappears and becomes so commonplace that it does not have meaning associated with it.</p>
 
-<img src="../media/refs/hari.png"/>
+<img src="../media/refs/hari.png" alt='Natalya Bondarchuk as Hari Kelvin in Solaris'/>
 
 <p>The <a href='moloch.html'>desert of cities</a> is equal to the desert of sand — the jungle of signs is equal to that of the forests — the vertigo of simulacra is equal to that of nature — only the vertiginous seduction of a <a href='collapse.html'>dying system</a> remains, in which work buries work, in which <a href='commodity.html'>value</a> buries value. <a href='https://en.wikipedia.org/wiki/Jean_Baudrillard' target='_blank'>~</a></p>
 
@@ -24,7 +29,12 @@
 <p>Because to tell the truth, nothing happens anymore. Nothing any longer has the time to happen. There is no duration left for anything to unfold in. Nothing can anchor itself in the world long enough to make sense. While the present still has a duration, the hyperpresent no longer does.</p>
 <h5>—After Death, Francois J Bonnet</h5>
 
-<img src='../media/refs/bruno.jpg'/>
+<figure>
+    <img src='../media/refs/bruno.jpg' alt='A young girl looks at a boy swinging from a vine.'/>
+    <figcaption>
+        <a href='https://en.wikisource.org/wiki/File:Sylvie_and_Bruno_illustration_scan_49.png'>Illustration by Harry Furniss in <cite>Sylvie and Bruno Concluded</cite></a>
+    </figcaption>
+</figure>
 
 <q>It has never been spread out, yet, they said it would cover the whole country, and shut out the sunlight! So we now use the country itself, as its own map, and I assure you it does nearly as well.</q>
 <h5>Lewis Carroll(Sylvie)</h5>

--- a/src/content/technocracy.htm
+++ b/src/content/technocracy.htm
@@ -2,7 +2,7 @@
 
 <p>Today, you're either above the API or below the API. You either tell <a href='moloch.html'>robots</a> what to do, or are told by robots what to do.</p>
 
-<img src='../media/refs/dafu.png' width='140'/>
+<img src='../media/refs/dafu.png' width='140' alt='Dafu from the manga Litchi☆Hikari Club'/>
 
 <p><b>The end of work</b> is the upcoming abstraction and machine automation of mostly all that is currently understood as work. Inside capitalism, the critical moment is specifically where technology meets capital: who gets to own this <i>capital</i>; the "factory without the worker".</p>
 
@@ -14,7 +14,7 @@
 
 <p>By separating intellectual and physical labor the state took power away from both types of workers. The manual laborers could then only build what others had planned and the planners no longer had the capacity to build anything at all.</p>
 
-<img src='../media/refs/ohm.png' width="350" />
+<img src='../media/refs/ohm.png' width="350" alt='Nausicaä reaching out to a small suspended Ohm'/>
 
 <q>Suffering and tragedy and folly will not disappear in a purified world.</q>
 
@@ -38,7 +38,7 @@
 <q>They constantly try to escape<br />From the darkness outside and within<br />By dreaming of systems so perfect that no one will need to be good.<br />But the man that is will shadow<br />The man that <a href='simulacra.html'>pretends to be</a>.</q>
 <h5>T.S. Eliot, The Rock </h5>
 
-<img src='../media/refs/immortan.png'/>
+<img src='../media/refs/immortan.png' alt='Immortan Joe from Mad Max: Fury Road'/>
 
 <p>He drops water onto hordes of irradiated wastrels like a Roman emperor showering plebs with bread and circuses. “Do not become addicted to water,” he cautions them.</p>
 

--- a/src/content/technology.htm
+++ b/src/content/technology.htm
@@ -4,13 +4,19 @@
 
 <p>The social media user does not post for enjoyment, they enjoy the indulgent masochism of its dopamine exhaustion, they indulge in it as they do a deep autumn depression, with an unconsciously mechanical action which draws them from their potential as a Being. Stripped to the core there is nothing new here, what is found once more is one's lust for sleep.<a href='https://www.meta-nomad.net/everything-happens-no-one-does-anything/' target='_blank'>~</a></p>
 
-<img src='../media/refs/technology.png' width='600'/>
+<figure role='group'>
+	<img src='../media/refs/technology.png' width='600' alt='Sequence of images. 1: Person sitting on couch watching TV. 2: TV displays a burger and says “Say Mcdonald’s to end commercial”. 3: Person standing with their arms in the air shouting “McDonald’s!”. 4: Original TV program resumes' />
+	<figcaption>
+		<a href='https://patft.uspto.gov/netacgi/nph-Parser?Sect1=PTO1&Sect2=HITOFF&p=1&u=/netahtml/PTO/srchnum.html&r=1&f=G&l=50&d=PALL&s1=8246454.PN.'>US patent 8,246,454: <cite>System for converting television commercials into interactive networked video games</cite></a>
+	</figcaption>
+</figure>
+
 
 <q>A long-continuing day was given to them for the life they loved so much, for they died not by grievous ills consumed, but as o'ercome by sleep.</q>
 
 <p>If we are surrounded by life, why is the universe silent? Shouldn’t the whole universe be a noisy social media feed, everyone vying for everyone else’s attention? The dark forest theory explaining that communication, because it reveals our existence to others, is a sign of stupidity rather than intelligence.</p>
 
-<img src='../media/refs/internet.png' width='300'/>
+<img src='../media/refs/internet.png' width='300' alt='Internet ‘may be just a passing fad as millions give up on it’'/>
 
 <q>If we listened to people like you, more or less vagabonds and barefoot tramps, we would not have got beyond the bicycle. That's just it! we would ride bikes in the cities.</q>
 <h5>Bernard Moitessier, The Long Way</h5>


### PR DESCRIPTION
This PR adds alt text to the images that appear on the [Technology pages](https://wiki.xxiivv.com/site/technology.html).

I would've liked to also provide a caption for the "Paper Computer" image with a link to a [Wikimedia page with more information on it](https://commons.wikimedia.org/wiki/File:Card_puncher_-_NARA_-_513295.jpg), but that doesn't seem possible at the moment.