### PR TITLE
unicycle: improve usability

### DIFF
--- a/etc/unicycle/emu.js
+++ b/etc/unicycle/emu.js
@@ -3,7 +3,7 @@
 function Console(emu)
 {
 	this.buffer = ""
-	this.display = null
+	this.display = console.log
 
 	this.i = (char) => {
 		console.log("i",char)
@@ -11,7 +11,7 @@ function Console(emu)
 
 	this.send = (char) => {
 		if(char == 0x0a) {
-			this.display.innerHTML = this.buffer
+			this.display(this.buffer)
 			this.buffer = ""
 		}
 		else{

--- a/etc/unicycle/index.html
+++ b/etc/unicycle/index.html
@@ -17,7 +17,7 @@
 		let res = document.getElementById("res")
 		let emulator = new Emu()
 
-		emulator.console.display = res
+		emulator.console.display = (buffer) => {res.innerText = buffer}
 		emulator.uxn.load(program).eval(0x0100)
 
 		asm_el.addEventListener("keydown", function (event) {

--- a/etc/unicycle/index.html
+++ b/etc/unicycle/index.html
@@ -8,28 +8,31 @@
 	<script src="uxn.js"></script>
 </head>
 <body>
-	<input type="value" placeholder="Uxntal Interpreter" id="asm" autofocus/>
-	<span id="res"></span>
+	<form id="form" aria-label="Uxntal Interpreter">
+		<label for="asm">Input</label>
+		<input type="text" name="asm" id="asm" placeholder="Enter uxntal…" autofocus style="font-family: monospace;"/>
+		<input type="submit" value="Execute">
+		<output id="res" name="res" for="asm" style="font-family: monospace;"></output>
+	</form>
 	<script type="text/javascript">
 		'use strict'
 
 		let asm_el = document.getElementById("asm")
+		let form_el = document.getElementById("form")
 		let res = document.getElementById("res")
 		let emulator = new Emu()
 
-		emulator.console.display = (buffer) => {res.innerText = buffer}
+		emulator.console.display = (buffer) => {res.value = buffer}
 		emulator.uxn.load(program).eval(0x0100)
 
-		asm_el.addEventListener("keydown", function (event) {
-			if (event.key === "Enter") {
-				event.preventDefault();
-				for (let i = 0; i < asm_el.value.length; i++) 
-					emulator.console.input(asm_el.value.charAt(i).charCodeAt(0))
-				emulator.console.input(0x0a)
-				asm_el.value = ""
-			}
+		form_el.addEventListener("submit", (event) => {
+			event.preventDefault()
+			for (let i = 0; i < asm_el.value.length; i++)
+				emulator.console.input(asm_el.value.charAt(i).charCodeAt(0))
+			emulator.console.input(0x0a)
+			asm_el.value = ""
 		})
 	</script>
 	<noscript>This form requires Javascript.</noscript>
 </body>
-</html> 
+</html>

--- a/etc/unicycle/index.html
+++ b/etc/unicycle/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8"/>
+	<title>Uxntal Interpreter</title>
 	<script src="program.js"></script>
 	<script src="emu.js"></script>
 	<script src="uxn.js"></script>

--- a/src/htm/uxntal.htm
+++ b/src/htm/uxntal.htm
@@ -128,7 +128,7 @@ span.comment { color:#aaa }
 
 <p>For example, type <code>#12 #34 ADD</code> and press enter, to see the result.</p>
 
-<iframe src="../etc/unicycle/index.html" frameborder="0" style="background: #efefef;height: 40px;overflow: hidden;"></iframe>
+<iframe title="Uxntal Interpreter" src="../etc/unicycle/index.html" frameborder="0" style="background: #efefef;height: 40px;overflow: hidden;"></iframe>
 
 <h2>Addressing</h2>
 

--- a/src/htm/uxntal.htm
+++ b/src/htm/uxntal.htm
@@ -77,7 +77,7 @@
 <span class='comment'>( init )</span>
 
 |0100 <span class='label'>@program</span>
-	
+
 	<b>;hello-word</b>
 
 	<span class='label'>&while</span>
@@ -86,7 +86,7 @@
 	POP2
 
 	HALT
-	
+
 BRK
 
 <span class='label'>@hello-word</span> "Hello 20 "World! 00
@@ -126,7 +126,7 @@ span.comment { color:#aaa }
 
 <p>The following input field is a small interactive terminal to play with the uxntal opcodes and see their effect on the stack. You can also use <a href='bicycle.html'>unicycle.rom</a> directly in your uxn emulator.</p>
 
-<p>For example, type <code>#12 #34 ADD</code> and press enter, to see the result.</p>
+<p>For example, type <code>#12 #34 ADD</code> and press Execute to see the result.</p>
 
 <iframe title="Uxntal Interpreter" src="../etc/unicycle/index.html" frameborder="0" style="background: #efefef;height: 40px;overflow: hidden;"></iframe>
 
@@ -157,4 +157,3 @@ pre span.comment { color:#666; }
 	<li><a href='https://git.sr.ht/~rabbits/drifblim' target='_blank'>Drifblim Assembler</a>, self-hosted</li>
 	<li><a href='https://git.sr.ht/~rabbits/uxn/blob/main/src/uxnasm.c' target='_blank'>Assembler Source</a>, ANSI C</li>
 </ul>
-


### PR DESCRIPTION
This PR makes several changes to Varvara's Unicycle to improve usability and accessibility:

- Added `title` attribute to the `<iframe>` and `<title>` to the document itself for [accessibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#accessibility_concerns=).
- In `emu.js`, change `Console.display` to be a function instead of an `HTMLElement` to make it more flexible.
- `unicycle/index.html`:
   - Use `<form>` with a submit button to give users more than one way to execute the uxntal statement.
   - Use an [`<output>` element](https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element) to show the result of the uxntal evaluation in a more semantic way.
   - Style the input and output in monospace.
   - Change placeholder to be more instructive.