### PR TITLE
Fixed hyperlink for vectors in uxntal reference

### DIFF
--- a/site/uxntal_reference.html
+++ b/site/uxntal_reference.html
@@ -27,7 +27,7 @@
 <img src='../media/generic/usl/brk.png' class='usl'/>
 <p>
 <code class='op'>BRK <code class="sig">--</code></code>
-Ends the evalutation of the current <a href='#vector'>vector</a>, the BRK opcode has no <a href='#modes'>modes</a>.</p>
+Ends the evalutation of the current <a href='#vectors'>vector</a>, the BRK opcode has no <a href='#modes'>modes</a>.</p>
 
 <h3 id='lit'>Literal</h3>
 <p>

--- a/src/htm/uxntal_reference.htm
+++ b/src/htm/uxntal_reference.htm
@@ -23,7 +23,7 @@
 <img src='../media/generic/usl/brk.png' class='usl'/>
 <p>
 <code class='op'>BRK <code class="sig">--</code></code>
-Ends the evalutation of the current <a href='#vector'>vector</a>, the BRK opcode has no <a href='#modes'>modes</a>.</p>
+Ends the evalutation of the current <a href='#vectors'>vector</a>, the BRK opcode has no <a href='#modes'>modes</a>.</p>
 
 <h3 id='lit'>Literal</h3>
 <p>


### PR DESCRIPTION
On the uxntal reference page, the description for the BRK opcode contains a hyperlink to the vector description with id `vector`

I think this should be `vectors`, to reference the section on the page, of the same name, because a link above this redirects to the correct hyperlink `vectors`