### PR TITLE
Fix initial-scale in viewport meta tag

### DIFF
--- a/src/htm/meta_head.htm
+++ b/src/htm/meta_head.htm
@@ -1,2 +1,2 @@
 
-<meta charset="utf-8"/><meta name="viewport" content="width=device-width, inital-scale=1"/><link href="../links/main.css" type="text/css" rel="stylesheet"/><link href="../media/services/icon.png" type="image/png" rel="shortcut icon"/>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link href="../links/main.css" type="text/css" rel="stylesheet"/><link href="../media/services/icon.png" type="image/png" rel="shortcut icon"/>


### PR DESCRIPTION
Noticed that there was a seeming typo in the viewport meta tag `inital-scale=1`, which is unrecognized at least in Chrome.
![Screenshot 2023-06-20 at 0 58 24](https://github.com/XXIIVV/oscean/assets/13048797/7a8e7de5-273b-46e3-a670-fda265cd80dd)
Fixes it to `initial-scale`, adding the missing `i`.