### PR TITLE
Fix missing space in comment

### DIFF
--- a/src/htm/varvara.htm
+++ b/src/htm/varvara.htm
@@ -250,7 +250,7 @@ uxncli file.rom arg1 arg2
 @on-screen <i>( -> )</i>
 	[ LIT &frame $1 ] INCk ,&frame STR
 	#01 AND ?&>skip
-		( 30 times per second)
+		( 30 times per second )
 		&>skip
 	BRK
 </pre>


### PR DESCRIPTION
Copied this a few times from the docs now, figured I'd send a quick pr to fix the comment