### PR TITLE
Make text inside <input> visible on dark mode

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -56,6 +56,7 @@ div.codeview pre a { float:right;color:#72dec2;text-decoration:none;font-weight:
 	* { color:#fff }
 	body { background:#000 }
 	main a:hover, main a:hover > *, nav a:hover, nav a:hover > * { background-color:#fff;color:#000;text-decoration:none }
+	input { color:#000 }
 	img[src*="svg"], img[src*="png"] { filter:invert(1) hue-rotate(180deg) }
 	main pre { background:#111 }
 	main table { border-style:solid }


### PR DESCRIPTION
This PR fixes the issue where input text is invisible in dark mode due to the global `color: #fff` rule.

## Solution:

I've added an exception to the dark mode styles:

```css
@media (prefers-color-scheme: dark) {
    input { color: #000 }
}
```

Alternatively, we can use the `:not()` pseudo-class to exclude input fields globally:

```css
@media (prefers-color-scheme: dark) {
    *:not(input) { color: #fff }
}
```

The first approach is simple, while the second allows for easy future exceptions by adding them to the list of elements in the `:not()` pseudo-class.

I am happy to implement another solution as well, just let me know :)