### PR TITLE
fix: subtle bug in ufx drawing routine

### DIFF
--- a/site/file_formats.html
+++ b/site/file_formats.html
@@ -194,8 +194,8 @@ JMP2r
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #20 SUB #00 SWP
-		( addr ) DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP
+		( addr ) #20 SUB DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2

--- a/site/file_formats.html
+++ b/site/file_formats.html
@@ -194,8 +194,8 @@ JMP2r
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #00 SWP
-		( addr ) #20 SUB DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP DUP2
+		( addr ) #20 SUB #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2

--- a/site/ufx_format.html
+++ b/site/ufx_format.html
@@ -30,8 +30,8 @@
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #00 SWP DUP2
-		( addr ) #0020 SUB #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP
+		( addr ) #20 SUB DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2

--- a/site/ufx_format.html
+++ b/site/ufx_format.html
@@ -30,8 +30,8 @@
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #20 SUB #00 SWP
-		( addr ) DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP DUP2
+		( addr ) #0020 SUB #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2

--- a/site/ufx_format.html
+++ b/site/ufx_format.html
@@ -30,8 +30,8 @@
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #00 SWP
-		( addr ) #20 SUB DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP DUP2
+		( addr ) #20 SUB #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2

--- a/src/htm/ufx_format.htm
+++ b/src/htm/ufx_format.htm
@@ -22,8 +22,8 @@
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #00 SWP
-		( addr ) #20 SUB DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP DUP2
+		( addr ) #20 SUB #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2

--- a/src/htm/ufx_format.htm
+++ b/src/htm/ufx_format.htm
@@ -22,8 +22,8 @@
 @draw-uf2 ( text* -- )
 	[ LIT2 15 -Screen/auto ] DEO
 	&>while ( -- )
-		LDAk #20 SUB #00 SWP
-		( addr ) DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
+		LDAk #00 SWP
+		( addr ) #20 SUB DUP2 #50 SFT2 ;font/glyphs ADD2 .Screen/addr DEO2
 		( move ) ;font ADD2 LDA #00 SWP .Screen/x DEI2 ADD2
 		( draw ) [ LIT2 01 -Screen/sprite ] DEOk DEO
 		.Screen/x DEO2


### PR DESCRIPTION
The ufx header is 256 width bytes, indexed by glyph number. The previous code subtracted 20h *before* getting the width of a glyph - while this works for character data, it also means that the widths are indexed incorrectly.