### PR TITLE
Improve uxnrepl debug legibility via <dialog> debug overlay

### DIFF
--- a/etc/uxnrepl/index.html
+++ b/etc/uxnrepl/index.html
@@ -73,7 +73,8 @@ let run_el = document.getElementById("run")
 let step_el = document.getElementById("step")
 let save_el = document.getElementById("save")
 
-// Replaces alert() with a styled <dialog> when the browser supports it
+// Enhance debug with <dialog> when available
+
 let dialog_el = document.getElementById('dialog')
 let dialog_content_el
 let dialog_buttons_el
@@ -94,7 +95,7 @@ if(typeof HTMLDialogElement === 'function') {
 		dialog_el.showModal()
 	}
 }
-else { // Delete unsupported elements and null their variables
+else { // Delete unsupported <dialog> and null variables
 	dialog_el.remove()
 	dialog_el = null
 	dialog_content_el = null

--- a/etc/uxnrepl/index.html
+++ b/etc/uxnrepl/index.html
@@ -54,6 +54,13 @@
 			<option value="10_tal">10. Debugging</option>
 		</select>
 	</div>
+	<dialog id="dialog">
+		<h3>Debug</h3>
+		<div id="dialog-content"></div>
+		<form id="dialog-buttons" method="dialog">
+			<input type="button" value="OK" id="dialog-ok" autofocus></input>
+		</form>
+	</dialog>
 	<script type="text/javascript">
 'use strict'
 
@@ -65,6 +72,35 @@ let wst_el = document.getElementById("wst")
 let run_el = document.getElementById("run")
 let step_el = document.getElementById("step")
 let save_el = document.getElementById("save")
+
+// Replaces alert() with a styled <dialog> when the browser supports it
+let dialog_el = document.getElementById('dialog')
+let dialog_content_el
+let dialog_buttons_el
+
+if(typeof HTMLDialogElement === 'function') {
+	dialog_content_el = document.getElementById('dialog-content')
+	dialog_buttons_el = document.getElementById('dialog-buttons')
+	// Delegated event handler for all dialog buttons (confirm, prompt, etc)
+	dialog_buttons_el.addEventListener("click", (e) => {
+		let target = e.target
+		if(target === undefined || target.tagName !== 'INPUT' || target.type !== 'button')
+			return
+		e.stopPropagation()
+		dialog_el.close()
+	})
+	alert = function alert(message) {
+		dialog_content_el.innerHTML = `<pre>${message}</pre>`
+		dialog_el.showModal()
+	}
+}
+else { // Delete unsupported elements and null their variables
+	dialog_el.remove()
+	dialog_el = null
+	dialog_content_el = null
+	dialog_buttons_el = null
+}
+
 
 document.body.className = "active"
 
@@ -80,15 +116,6 @@ function assemble(query, program) {
 	emu_asm.console.input(0x0a, 2)
 	emu_asm.console.input(0x00, 4)
 	return rom_length
-}
-
-function alert(message) {
-       const dialog = document.querySelector("#dialog-root");
-       const dialog_title = dialog.querySelector('#dialog-title');
-       dialog_title.innerHTML = 'Alert';
-       const content_node = dialog.querySelector("#dialog-content");
-       content_node.innerHTML = `<pre>${message}</pre>`;
-       dialog.showModal();
 }
 
 let opcodes = [
@@ -216,19 +243,17 @@ document.getElementById('examples').addEventListener('change', (e) => {
 		div#menu select { float:right }
 		body.active textarea { height:calc(100% - 140px); }
 		body.active div#term, body.active div#menu { display:block }
-		#run, #step, #save { cursor:pointer; background:#000; color:white; border:0px; border-radius:100px; line-height:24px; padding:0px 10px; font-size:12px }
+		#run, #step, #save , #dialog-ok { cursor:pointer; background:#000; color:white; border:0px; border-radius:100px; line-height:24px; padding:0px 10px; font-size:12px }
 		#step, #save { background: #fff; color:black}
 		#save { float:right; margin-left:10px }
 		#run:hover, #step:hover, #save:hover { background: #58ac96; color:#000 }
-		#dialog-content > pre { background: #000; color: white;}
-		#dialog-root > form { width: 100%; text-align: right; }
+		#run:hover, #step:hover, #save:hover, #dialog-ok:hover { background: #58ac96; color:#000 }
+		dialog { background:#a4f4e0; display: none; padding: 10px; padding-bottom: 0; }
+		dialog[open] { display: block; }
+		dialog > * { margin: 0; margin-bottom: 10px; }
+		::backdrop { background: #a4f4e0; opacity: 0.6; }
+		#dialog-content > pre { background: #000; color: white; padding: 10px; }
+		#dialog > form { width: 100%; text-align: right; }
 	</style>
-       <dialog id="dialog-root">
-               <h3 id="dialog-title"></h3>
-               <div id="dialog-content"></div>
-               <form method="dialog">
-                       <button autofocus>OK</button>
-               </form>
-       </dialog>
 </body>
 </html>

--- a/etc/uxnrepl/index.html
+++ b/etc/uxnrepl/index.html
@@ -82,6 +82,15 @@ function assemble(query, program) {
 	return rom_length
 }
 
+function alert(message) {
+       const dialog = document.querySelector("#dialog-root");
+       const dialog_title = dialog.querySelector('#dialog-title');
+       dialog_title.innerHTML = 'Alert';
+       const content_node = dialog.querySelector("#dialog-content");
+       content_node.innerHTML = `<pre>${message}</pre>`;
+       dialog.showModal();
+}
+
 let opcodes = [
 	"LIT", "INC", "POP", "NIP", "SWP", "ROT", "DUP", "OVR",
 	"EQU", "NEQ", "GTH", "LTH", "JMP", "JCN", "JSR", "STH",
@@ -211,6 +220,15 @@ document.getElementById('examples').addEventListener('change', (e) => {
 		#step, #save { background: #fff; color:black}
 		#save { float:right; margin-left:10px }
 		#run:hover, #step:hover, #save:hover { background: #58ac96; color:#000 }
+		#dialog-content > pre { background: #000; color: white;}
+		#dialog-root > form { width: 100%; text-align: right; }
 	</style>
+       <dialog id="dialog-root">
+               <h3 id="dialog-title"></h3>
+               <div id="dialog-content"></div>
+               <form method="dialog">
+                       <button autofocus>OK</button>
+               </form>
+       </dialog>
 </body>
 </html>


### PR DESCRIPTION
**TL;DR:** Make unxrepl's debug pop-up a [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) with zoom, style, and text select support

It uses `alert()` as the fallback on older browsers. This is what the `<dialog>` looks like when zoomed via `CTRL +`:

| 200% Zoom |
| :--: |
| <img src="https://github.com/user-attachments/assets/58b2e7d8-e20e-4190-adc8-40b3e65e2a62" height="300" width="auto" style="display: inline-block;"/><br/><i>Chrome-derived browser on Linux, 1080p display, no system-wide scaling</i> |

## Why?

| Pre-PR `alert()` Behavior | Visual Accessibility Issue | Fixed by PR? (`<dialog>`) |
|--------------|---------------------------|---|
| Does not scale with browser zoom | Can't resize text via `CTRL +` / `CTRL -` | Yes, debug box scales | 
| Prevents selecting text\* | Can't [enhance contrast by selecting text](https://news.ycombinator.com/item?id=4839436) | Yes, also allows custom behavior |
| Cannot be styled | Can't improve legibility via user stylesheets | Yes, can style box and [`::backdrop`](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop) |
| Pop-up box does not show modal state | White bg can drown small dark system-themed `alert()` boxes | Yes, modal backdrop uses inactive panel area color |

\* *May depend on browser, platform, desktop environment, and build flags.*

## Details

When `typeof HTMLDialogElement === 'function'`,  the default [`alert()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) function is overridden by a styled [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog). I did my best to match existing code style and design language:

* Black button for primary buttons
* Teal for:
   * tool panel areas which are non-active UI area 
   * overlay backdrop

### How's Compatibility / Permacomputing?

MDN's [`<dialog>` compatibility table](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#browser_compatibility):

|  Fist `<dialog>` Support | Browsers |
|-----------------------|---------------|
| 2014+                | Chrome-likes (Desktop, Android web view, all Opera variants) |
| 2022+                | Firefox, Safari (Desktop & Mobile) |

I had the same device I tested [Tote](https://hundredrabbits.itch.io/tote) on as my lower bound. It's a [Samsung Galaxy Note 4 (2014)](https://en.wikipedia.org/wiki/Samsung_Galaxy_Note_4):

* It _should_ be compatible with `<dialog>` according to the chart above
* I haven't had a chance to try these changes on it yet
* I can try if you'd like
