### PR TITLE
Prevent context menu on uxn5 canvas to fix noodle

### DIFF
--- a/etc/uxn5/src/devices/screen.js
+++ b/etc/uxn5/src/devices/screen.js
@@ -25,6 +25,7 @@ function Screen(emu)
 	this.init = () => {
 		this.display = document.getElementById("display");
 		this.displayctx = this.display.getContext("2d", {"willReadFrequently": true})
+		this.display.addEventListener("contextmenu", (e) => e.preventDefault())
 		this.display.addEventListener("pointermove", emu.mouse.on_move)
 		this.display.addEventListener("pointerdown", emu.mouse.on_down)
 		this.display.addEventListener("pointerup", emu.mouse.on_up)


### PR DESCRIPTION
<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>
<tr><td>

(Dark input fields are a browser extension, not part of uxn)

https://github.com/user-attachments/assets/2591f640-3e28-42ac-922a-4f4f91075adf


</td>
<td>

(Extension switched off)

https://github.com/user-attachments/assets/a2f5f27a-cede-43cd-b082-e80617296b7f


</td>
</tr>
</table>

